### PR TITLE
Fixed unsafe type definitions in select

### DIFF
--- a/test/select.ts
+++ b/test/select.ts
@@ -17,7 +17,9 @@ test('select', async () => {
 
   const task = async () => {
     const out = await select({ ch1: ch1 });
-    results.push(out.m);
+    if (out.m) {
+      results.push(out.m);
+    }
   };
 
   const p1 = task();
@@ -160,7 +162,7 @@ test('signal', async () => {
     case undefined:
       break;
     case 'a':
-      out.m satisfies string;
+      out.m satisfies string | undefined;
     // shouldn't run, fall-through
     default:
       assert.fail('bad');


### PR DESCRIPTION
The generics of the select types were a little over complicated which made the underlying types harder to re-use.

The fallback optional parameters didn't accurately reflect the generic values so adding a conditional return type fixed the discrepancy. 

Removing the `any` types exposed a few bugs in the interface like `m` potentially being undefined, and the optional param fallback values not always being accurately represented in the return.